### PR TITLE
feat: add dhis2 metadata codesystems

### DIFF
--- a/public/assets/AttributesCodeSystem.fsh.handlebars
+++ b/public/assets/AttributesCodeSystem.fsh.handlebars
@@ -1,0 +1,7 @@
+CodeSystem: Dhis2TrackedEntityAttributesCS
+Id: dhis2-tracked-entity-attributes-cs
+Title: "Dhis2 Tracked Entity Attribute Code System"
+Description: "Code system for {{count}} unique DHIS2 tracked entity attributes"
+{{#each elements as |element|}}
+* #{{element.id}} "{{element.name}}" "{{#if element.description}}{{{escapeQuotes element.description}}}{{else}}{{{escapeQuotes element.name}}}{{/if}}"
+{{/each}}

--- a/public/assets/DataElementsCodeSystem.fsh.handlebars
+++ b/public/assets/DataElementsCodeSystem.fsh.handlebars
@@ -1,0 +1,7 @@
+CodeSystem: Dhis2DataElementsCS
+Id: dhis2-data-elements-cs
+Title: "DHIS2 Data Elements Code System"
+Description: "Code system for {{count}} unique DHIS2 data elements from all selected programs"
+{{#each elements as |element|}}
+* #{{element.id}} "{{element.name}}" "{{#if element.description}}{{{escapeQuotes element.description}}}{{else}}{{{escapeQuotes element.name}}}{{/if}}"
+{{/each}}

--- a/public/assets/ProgramLogicalModel.fsh.handlebars
+++ b/public/assets/ProgramLogicalModel.fsh.handlebars
@@ -12,6 +12,7 @@ Description: "{{{escapeQuotes trackerProgram.description}}}"
 {{#if programTEA.trackedEntityAttribute.optionSet}}
 * {{toFhirDataElementName programTEA.trackedEntityAttribute}} from {{toPascalCase programTEA.trackedEntityAttribute.optionSet.name}}VS (required)
 {{/if}}
+  * ^code[+] = Dhis2TrackedEntityAttributesCS#{{programTEA.trackedEntityAttribute.id}}
 {{/trackerProgram.programTrackedEntityAttributes}}
 {{#programStages as |programStage|}}
 * {{toCamelCase programStage.name}} 0..{{isRepeatable programStage.repeatable}} {{toPascalCase programStage.name}} "{{{escapeQuotes (toFhirElementDescription programStage)}}}"

--- a/public/assets/ProgramStageLogicalModel.fsh.handlebars
+++ b/public/assets/ProgramStageLogicalModel.fsh.handlebars
@@ -11,5 +11,6 @@ Description: "{{{escapeQuotes programStage.description}}}"
 {{#if programStageDataElement.dataElement.optionSet}}
 * {{toFhirDataElementName programStageDataElement.dataElement}} from {{toPascalCase programStageDataElement.dataElement.optionSet.name}}VS (required)
 {{/if}}
+  * ^code[+] = Dhis2DataElementsCS#{{programStageDataElement.dataElement.id}}
 {{/programStageDataElements}}
 {{/with}}

--- a/src/hooks/useTemplates.js
+++ b/src/hooks/useTemplates.js
@@ -6,6 +6,8 @@ export const templateFileNames = [
     { key: 'codeSystemTemplate', fileName: 'CodeSystem.fsh.handlebars' },
     { key: 'valueSetTemplate', fileName: 'ValueSet.fsh.handlebars' },
     { key: 'questionnaireTemplate', fileName: 'Questionnaire.fsh.handlebars'},
+    {key: 'dataElementsCodeSystemTemplate', fileName: 'DataElementsCodeSystem.fsh.handlebars'},
+    {key: 'attributesCodeSystemTemplate', fileName: 'AttributesCodeSystem.fsh.handlebars'}
 ]
 
 export const useTemplates = () => {

--- a/src/hooks/useTrackerPrograms.js
+++ b/src/hooks/useTrackerPrograms.js
@@ -12,7 +12,7 @@ const trackerProgramQuery = {
         "description",
         "enrollmentDateLabel",
         "incidentDateLabel",
-        "programTrackedEntityAttributes[mandatory,trackedEntityAttribute[name,shortName,formName,displayName,valueType,description,optionSet[name,valueType,options[code,name]]]]",
+        "programTrackedEntityAttributes[mandatory,trackedEntityAttribute[id,name,shortName,formName,displayName,valueType,description,optionSet[name,valueType,options[code,name]]]]",
         "programStages[name,description,repeatable,programStageSections[name,description,displayFormName,dataElements[id]],programStageDataElements[compulsory,dataElement[id,name,shortName,formName,displayName,valueType,optionSet[name,options[code,name]]]]]",
       ]
     },

--- a/src/tests/attributesToCodeSystemMapping.test.js
+++ b/src/tests/attributesToCodeSystemMapping.test.js
@@ -1,0 +1,30 @@
+import Handlebars from "handlebars";
+import fs from 'fs';
+import path from 'path';
+import { registerHelpers } from "../utils/handlebarsHelpers";
+
+registerHelpers();
+
+const template = fs.readFileSync(path.join(__dirname, "../../public/assets/AttributesCodeSystem.fsh.handlebars"), "utf8");
+const mockData = JSON.parse(fs.readFileSync(path.join(__dirname, "./resources/mockAttributes.json"), "utf8"));
+const emptyMockData = JSON.parse(fs.readFileSync(path.join(__dirname, "./resources/mockEmptyCodeSystem.json"), "utf8"));
+const expectedOutput = fs.readFileSync(path.join(__dirname, "./resources/expectedAttributesCodeSystem.fsh"), "utf8");
+const expectedEmptyOutput = 
+`CodeSystem: Dhis2TrackedEntityAttributesCS
+Id: dhis2-tracked-entity-attributes-cs
+Title: "Dhis2 Tracked Entity Attribute Code System"
+Description: "Code system for 0 unique DHIS2 tracked entity attributes"`;
+
+describe("DHIS2 Tracked Entity Attributes to CodeSystem FSH Mapping", () => {
+  it("Should correctly map tracked entity attributes to a Code System in FSH format", () => {
+    const compiledTemplate = Handlebars.compile(template);
+    const resultFSH = compiledTemplate(mockData).trim();
+    expect(resultFSH).toEqual(expectedOutput.trim());
+  });
+  
+  it("Should handle an empty collection of tracked entity attributes", () => {
+    const compiledTemplate = Handlebars.compile(template);
+    const resultFSH = compiledTemplate(emptyMockData).trim();
+    expect(resultFSH).toEqual(expectedEmptyOutput.trim());
+  });
+});

--- a/src/tests/dataElementsToCodeSystemMapping.test.js
+++ b/src/tests/dataElementsToCodeSystemMapping.test.js
@@ -1,0 +1,31 @@
+import Handlebars from "handlebars";
+import fs from 'fs';
+import path from 'path';
+import { registerHelpers } from "../utils/handlebarsHelpers";
+
+registerHelpers();
+
+const template = fs.readFileSync(path.join(__dirname, "../../public/assets/DataElementsCodeSystem.fsh.handlebars"), "utf8");
+const mockData = JSON.parse(fs.readFileSync(path.join(__dirname, "./resources/mockDataElements.json"), "utf8"));
+const emptyMockData = JSON.parse(fs.readFileSync(path.join(__dirname, "./resources/mockEmptyCodeSystem.json"), "utf8"));
+const expectedOutput = fs.readFileSync(path.join(__dirname, "./resources/expectedDataElementsCodeSystem.fsh"), "utf8");
+
+const expectedEmptyOutput = 
+`CodeSystem: Dhis2DataElementsCS
+Id: dhis2-data-elements-cs
+Title: "DHIS2 Data Elements Code System"
+Description: "Code system for 0 unique DHIS2 data elements from all selected programs"`;
+
+describe("DHIS2 Data Elements to CodeSystem FSH Mapping", () => {
+  it("Should correctly map data elements to a Code System in FSH format", () => {
+    const compiledTemplate = Handlebars.compile(template);
+    const resultFSH = compiledTemplate(mockData).trim();
+    expect(resultFSH).toEqual(expectedOutput.trim());
+  });
+  
+  it("Should handle an empty collection of data elements", () => {
+    const compiledTemplate = Handlebars.compile(template);
+    const resultFSH = compiledTemplate(emptyMockData).trim();
+    expect(resultFSH).toEqual(expectedEmptyOutput.trim());
+  });
+});

--- a/src/tests/resources/expectedAttributesCodeSystem.fsh
+++ b/src/tests/resources/expectedAttributesCodeSystem.fsh
@@ -1,0 +1,7 @@
+CodeSystem: Dhis2TrackedEntityAttributesCS
+Id: dhis2-tracked-entity-attributes-cs
+Title: "Dhis2 Tracked Entity Attribute Code System"
+Description: "Code system for 3 unique DHIS2 tracked entity attributes"
+* #xyz123 "First Name" "Patient's first name"
+* #uvw456 "Last Name" "Patient's last name"
+* #rst789 "Gender" "Gender"

--- a/src/tests/resources/expectedDataElementsCodeSystem.fsh
+++ b/src/tests/resources/expectedDataElementsCodeSystem.fsh
@@ -1,0 +1,7 @@
+CodeSystem: Dhis2DataElementsCS
+Id: dhis2-data-elements-cs
+Title: "DHIS2 Data Elements Code System"
+Description: "Code system for 3 unique DHIS2 data elements from all selected programs"
+* #abc123 "TB Lab CD4" "TB Laboratory CD4 Count"
+* #def456 "HIV Status" "HIV Status"
+* #ghi789 "Weight in kg" "Patient weight in kilograms"

--- a/src/tests/resources/expectedProgramStageLogicalModel.fsh
+++ b/src/tests/resources/expectedProgramStageLogicalModel.fsh
@@ -4,6 +4,10 @@ Parent: Base
 Description: "Laboratory monitoring"
 * executionDate 0..1 date "Report date"
 * cd4 0..1 boolean "TB lab CD4"
+  * ^code[+] = Dhis2DataElementsCS#cd4001
 * creatinine 0..1 boolean "TB lab Creatinine"
+  * ^code[+] = Dhis2DataElementsCS#creat002
 * glucose 0..1 boolean "Tb lab Glucose"
+  * ^code[+] = Dhis2DataElementsCS#gluc003
 * hemoglobin 0..1 boolean "TB lab Hemoglobin"
+  * ^code[+] = Dhis2DataElementsCS#hemo004

--- a/src/tests/resources/expectedTbProgram.fsh
+++ b/src/tests/resources/expectedTbProgram.fsh
@@ -4,30 +4,54 @@ Parent: Base
 * enrollmentDate 1..1 date "Start of treatment date"
 * incidentDate 0..1 date "Start of treatment date"
 * firstName 1..1 string "This is the person's first name"
+  * ^code[+] = Dhis2TrackedEntityAttributesCS#firstName123
 * lastName 1..1 string "Last name"
+  * ^code[+] = Dhis2TrackedEntityAttributesCS#lastName456
 * gender 1..1 code "Gender"
 * gender from GenderVS (required)
+  * ^code[+] = Dhis2TrackedEntityAttributesCS#gender789
 * tbIdentifier 0..1 string "TB identifier"
+  * ^code[+] = Dhis2TrackedEntityAttributesCS#tbIdentifier012
 * age 0..1 Age "Age"
+  * ^code[+] = Dhis2TrackedEntityAttributesCS#age345
 * address 0..1 string "Country"
+  * ^code[+] = Dhis2TrackedEntityAttributesCS#address678
 * city 0..1 string "City"
+  * ^code[+] = Dhis2TrackedEntityAttributesCS#city901
 * state 0..1 string "State"
+  * ^code[+] = Dhis2TrackedEntityAttributesCS#state234
 * zipCode 0..1 decimal "Zip code"
+  * ^code[+] = Dhis2TrackedEntityAttributesCS#zipCode567
 * email 0..1 string "Email address"
+  * ^code[+] = Dhis2TrackedEntityAttributesCS#email890
 * phoneNumber 0..1 string "Phone number"
+  * ^code[+] = Dhis2TrackedEntityAttributesCS#phoneNumber123
 * residenceLocation 0..1 string "Residence location"
+  * ^code[+] = Dhis2TrackedEntityAttributesCS#residenceLocation456
 * motherMaidenName 0..1 string "Mother maiden name"
+  * ^code[+] = Dhis2TrackedEntityAttributesCS#motherMaidenName789
 * nationalIdentifier 0..1 string "National identifier"
+  * ^code[+] = Dhis2TrackedEntityAttributesCS#nationalIdentifier012
 * occupation 0..1 string "Occupation"
+  * ^code[+] = Dhis2TrackedEntityAttributesCS#occupation345
 * company 0..1 string "Company"
+  * ^code[+] = Dhis2TrackedEntityAttributesCS#company678
 * tbNumber 0..1 string "TB number"
+  * ^code[+] = Dhis2TrackedEntityAttributesCS#tbNumber901
 * vehicle 0..1 string "Vehicle"
+  * ^code[+] = Dhis2TrackedEntityAttributesCS#vehicle234
 * bloodType 0..1 string "Blood type"
+  * ^code[+] = Dhis2TrackedEntityAttributesCS#bloodType567
 * weightInKg 0..1 decimal "Weight in kg"
+  * ^code[+] = Dhis2TrackedEntityAttributesCS#weightInKg890
 * heightInCm 0..1 decimal "Height in cm"
+  * ^code[+] = Dhis2TrackedEntityAttributesCS#heightInCm123
 * latitude 0..1 string "Latitude"
+  * ^code[+] = Dhis2TrackedEntityAttributesCS#latitude456
 * longitude 0..1 string "Longitude"
+  * ^code[+] = Dhis2TrackedEntityAttributesCS#longitude789
 * uniqueIdentifier 0..1 string "Unique identiifer"
+  * ^code[+] = Dhis2TrackedEntityAttributesCS#uniqueIdentifier012
 * labMonitoring 0..* LabMonitoring "Laboratory monitoring"
 * tbVisit 0..1 TBVisit "Routine TB visit"
 * sputumSmearMicroscopyTest 0..* SputumSmearMicroscopyTest "Sputum smear microscopy test"

--- a/src/tests/resources/mockAttributes.json
+++ b/src/tests/resources/mockAttributes.json
@@ -1,0 +1,20 @@
+{
+    "elements": [
+      {
+        "id": "xyz123",
+        "name": "First Name",
+        "description": "Patient's first name"
+      },
+      {
+        "id": "uvw456",
+        "name": "Last Name",
+        "description": "Patient's last name"
+      },
+      {
+        "id": "rst789",
+        "name": "Gender",
+        "description": null
+      }
+    ],
+    "count": 3
+}

--- a/src/tests/resources/mockDataElements.json
+++ b/src/tests/resources/mockDataElements.json
@@ -1,0 +1,20 @@
+{
+    "elements": [
+      {
+        "id": "abc123",
+        "name": "TB Lab CD4",
+        "description": "TB Laboratory CD4 Count"
+      },
+      {
+        "id": "def456",
+        "name": "HIV Status",
+        "description": null
+      },
+      {
+        "id": "ghi789",
+        "name": "Weight in kg",
+        "description": "Patient weight in kilograms"
+      }
+    ],
+    "count": 3
+  }

--- a/src/tests/resources/mockEmptyCodeSystem.json
+++ b/src/tests/resources/mockEmptyCodeSystem.json
@@ -1,0 +1,4 @@
+{
+    "elements": [],
+    "count": 0
+}

--- a/src/tests/resources/mockProgramStage.json
+++ b/src/tests/resources/mockProgramStage.json
@@ -4,6 +4,7 @@
     "programStageDataElements": [
         {
             "dataElement": {
+                "id": "cd4001",
                 "name": "TB lab CD4",
                 "shortName": "CD4",
                 "valueType": "TRUE_ONLY",
@@ -13,6 +14,7 @@
         },
         {
             "dataElement": {
+                "id": "creat002",
                 "name": "TB lab Creatinine",
                 "shortName": "Creatinine",
                 "valueType": "TRUE_ONLY",
@@ -22,6 +24,7 @@
         },
         {
             "dataElement": {
+                "id": "gluc003",
                 "name": "Tb lab Glucose",
                 "shortName": "Glucose",
                 "valueType": "TRUE_ONLY",
@@ -31,6 +34,7 @@
         },
         {
             "dataElement": {
+                "id": "hemo004",
                 "name": "TB lab Hemoglobin",
                 "shortName": "Hemoglobin",
                 "valueType": "TRUE_ONLY",

--- a/src/tests/resources/mockTbProgram.json
+++ b/src/tests/resources/mockTbProgram.json
@@ -197,6 +197,7 @@
         {
             "mandatory": true,
             "trackedEntityAttribute": {
+                "id": "firstName123",
                 "name": "First name",
                 "shortName": "First name",
                 "description": "This is the person's first name",
@@ -207,6 +208,7 @@
         {
             "mandatory": true,
             "trackedEntityAttribute": {
+                "id": "lastName456",
                 "name": "Last name",
                 "shortName": "Last name",
                 "description": "Last name",
@@ -217,6 +219,7 @@
         {
             "mandatory": true,
             "trackedEntityAttribute": {
+                "id": "gender789",
                 "name": "Gender",
                 "shortName": "Gender",
                 "description": "Gender",
@@ -241,6 +244,7 @@
         {
             "mandatory": false,
             "trackedEntityAttribute": {
+                "id": "tbIdentifier012",
                 "name": "TB identifier",
                 "shortName": "TB identifier",
                 "valueType": "TEXT",
@@ -250,6 +254,7 @@
         {
             "mandatory": false,
             "trackedEntityAttribute": {
+                "id": "age345",
                 "name": "Age",
                 "shortName": "Age",
                 "description": "Age",
@@ -260,6 +265,7 @@
         {
             "mandatory": false,
             "trackedEntityAttribute": {
+                "id": "address678",
                 "name": "Address",
                 "shortName": "Address",
                 "description": "Country",
@@ -270,6 +276,7 @@
         {
             "mandatory": false,
             "trackedEntityAttribute": {
+                "id": "city901",
                 "name": "City",
                 "shortName": "City",
                 "description": "City",
@@ -280,6 +287,7 @@
         {
             "mandatory": false,
             "trackedEntityAttribute": {
+                "id": "state234",
                 "name": "State",
                 "shortName": "State",
                 "description": "State",
@@ -290,6 +298,7 @@
         {
             "mandatory": false,
             "trackedEntityAttribute": {
+                "id": "zipCode567",
                 "name": "Zip code",
                 "shortName": "Zip code",
                 "description": "Zip code",
@@ -300,6 +309,7 @@
         {
             "mandatory": false,
             "trackedEntityAttribute": {
+                "id": "email890",
                 "name": "Email",
                 "shortName": "Email",
                 "description": "Email address",
@@ -310,6 +320,7 @@
         {
             "mandatory": false,
             "trackedEntityAttribute": {
+                "id": "phoneNumber123",
                 "name": "Phone number",
                 "shortName": "Phone number",
                 "description": "Phone number",
@@ -320,6 +331,7 @@
         {
             "mandatory": false,
             "trackedEntityAttribute": {
+                "id": "residenceLocation456",
                 "name": "Residence location",
                 "shortName": "Residence location",
                 "valueType": "COORDINATE",
@@ -329,6 +341,7 @@
         {
             "mandatory": false,
             "trackedEntityAttribute": {
+                "id": "motherMaidenName789",
                 "name": "Mother maiden name",
                 "shortName": "Mother maiden name",
                 "description": "Mother maiden name",
@@ -339,6 +352,7 @@
         {
             "mandatory": false,
             "trackedEntityAttribute": {
+                "id": "nationalIdentifier012",
                 "name": "National identifier",
                 "shortName": "National identifier",
                 "description": "National identifier",
@@ -349,6 +363,7 @@
         {
             "mandatory": false,
             "trackedEntityAttribute": {
+                "id": "occupation345",
                 "name": "Occupation",
                 "shortName": "Occupation",
                 "description": "Occupation",
@@ -359,6 +374,7 @@
         {
             "mandatory": false,
             "trackedEntityAttribute": {
+                "id": "company678",
                 "name": "Company",
                 "shortName": "Company",
                 "description": "Company",
@@ -369,6 +385,7 @@
         {
             "mandatory": false,
             "trackedEntityAttribute": {
+                "id": "tbNumber901",
                 "name": "TB number",
                 "shortName": "TB number",
                 "description": "TB number",
@@ -379,6 +396,7 @@
         {
             "mandatory": false,
             "trackedEntityAttribute": {
+                "id": "vehicle234",
                 "name": "Vehicle",
                 "shortName": "Vehicle",
                 "description": "Vehicle",
@@ -389,6 +407,7 @@
         {
             "mandatory": false,
             "trackedEntityAttribute": {
+                "id": "bloodType567",
                 "name": "Blood type",
                 "shortName": "Blood type",
                 "description": "Blood type",
@@ -399,6 +418,7 @@
         {
             "mandatory": false,
             "trackedEntityAttribute": {
+                "id": "weightInKg890",
                 "name": "Weight in kg",
                 "shortName": "Weight in kg",
                 "description": "Weight in kg",
@@ -409,6 +429,7 @@
         {
             "mandatory": false,
             "trackedEntityAttribute": {
+                "id": "heightInCm123",
                 "name": "Height in cm",
                 "shortName": "Height in cm",
                 "description": "Height in cm",
@@ -419,6 +440,7 @@
         {
             "mandatory": false,
             "trackedEntityAttribute": {
+                "id": "latitude456",
                 "name": "Latitude",
                 "shortName": "Latitude",
                 "description": "Latitude",
@@ -429,6 +451,7 @@
         {
             "mandatory": false,
             "trackedEntityAttribute": {
+                "id": "longitude789",
                 "name": "Longitude",
                 "shortName": "Longitude",
                 "description": "Longitude",
@@ -439,6 +462,7 @@
         {
             "mandatory": false,
             "trackedEntityAttribute": {
+                "id": "uniqueIdentifier012",
                 "name": "Unique ID",
                 "shortName": "Unique identifier",
                 "description": "Unique identiifer",


### PR DESCRIPTION
[INTEROP-70](https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/boards/150?selectedIssue=INTEROP-70)

This PR adds explicit linkage between FHIR logical models and their source DHIS2 metadata by implementing references from each logical model element to its corresponding DHIS2 metadata using consolidated code systems.

Key changes:

* Add generation of two new code systems for tracked entity attributes and data elements that consolidate all metadata references
* Each code in these systems contains the DHIS2 metadata ID, name, and description field
* Add code references to each logical model element using the ^code[+] syntax to establish traceability back to DHIS2
* These references appear in the "Detailed Descriptions" tab when viewing logical models in the IG

https://github.com/user-attachments/assets/31bd1802-5cd3-4f6e-ba1b-145f0599ad43


Checklist:
- [ ] Add template for dhis2 data elements code system
- [ ] Add template for dhis2 TE attributes code system
- [ ] Ensure deduplication of coded elements
- [ ] Add tests
- [ ] Update existing tests 