### PR TITLE
fix: transformation improvements

### DIFF
--- a/public/assets/Questionnaire.fsh.handlebars
+++ b/public/assets/Questionnaire.fsh.handlebars
@@ -15,7 +15,7 @@ Usage: #definition
 
 {{#if programStageSections.length}}
 {{#each programStageSections as |section|}}
-* item[+].linkId = "{{toCamelCase section.name}}"
+* item[+].linkId = "{{toCamelCase section.name}}Group"
 * item[=].text = "{{{escapeQuotes section.name}}}"
 * item[=].type = #group
 * item[=]

--- a/src/tests/resources/expectedQuestionnaireWithGroups.fsh
+++ b/src/tests/resources/expectedQuestionnaireWithGroups.fsh
@@ -8,7 +8,7 @@ Usage: #definition
 * contained[+] = TBCSTreatmentOutcomeVS
 * contained[+] = TBCSDenotificationReasonsVS
 
-* item[+].linkId = "outcome"
+* item[+].linkId = "outcomeGroup"
 * item[=].text = "Outcome"
 * item[=].type = #group
 * item[=]
@@ -44,7 +44,7 @@ Usage: #definition
   * item[=].repeats = false
   * item[=].required = false
 
-* item[+].linkId = "outcomeStatus"
+* item[+].linkId = "outcomeStatusGroup"
 * item[=].text = "Outcome status"
 * item[=].type = #group
 * item[=]


### PR DESCRIPTION
Reviews of validation results from IGs across various HISP groups have revealed a list of improvements needed for the app:

- [ ] The link ids for groups and questions must be unique within the questionnaire

- [ ] There are some contained resources which are not referenced to from elsewhere in the containing resource nor does it refer to the containing resource (dom-3) - in questionnaires, including value sets that are not used in the questionnaire. 

- [ ] CodeSystems SHOULD have a stated value for the caseSensitive element so that users know the status and meaning of the code system clearly

- [ ] Published code systems SHOULD conform to the ShareableCodeSystem profile, which says that the element CodeSystem.experimental is mandatory, but it is not present

- [ ] Constraint failed: sdf-3: 'Each element definition in a snapshot must have a formal definition and cardinalities. (Remove execution date etc?)

- [ ] Published value sets SHOULD conform to the ShareableValueSet profile, which says that the element ValueSet.experimental is mandatory, but it is not present

- [ ] value should not start or finish with whitespace, such as  'PMTCT '